### PR TITLE
feat: add preferences page

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -40,6 +40,15 @@
               Matches
             </RouterLink>
           </li>
+          <li>
+            <RouterLink
+              to="/preferences"
+              class="text-sm text-white/80 hover:text-white transition"
+              :class="isActive('/preferences')"
+            >
+              Preferences
+            </RouterLink>
+          </li>
         </ul>
 
         <!-- Right actions -->

--- a/src/components/SwipeCarousel.vue
+++ b/src/components/SwipeCarousel.vue
@@ -19,27 +19,29 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onMounted } from 'vue'
 import SwipeCarouselCard from '@/components/SwipeCarouselCard.vue'
 import axios from 'axios'
+import { useCandidates } from '@/stores/candidates'
 
-const candidates = ref([] as any[])
+const store = useCandidates()
+const candidates = computed(() => store.list)
 
-// Load once or when needed
-async function fetchCandidates() {
-  const { data } = await axios.get('/api/users/candidates')
-  candidates.value = data || []
-}
-fetchCandidates()
+onMounted(() => {
+  if (!store.list.length) {
+    store.fetch()
+  }
+})
 
 async function onSwipe({ direction, userId }: { direction: 'left' | 'right'; userId: string }) {
   try {
-    await axios.post('/api/users/swipes', { targetId: userId, direction })
+    const API_BASE = import.meta.env.VITE_API_BASE
+    await axios.post(`${API_BASE}/users/swipes`, { targetId: userId, direction })
   } catch (e) {
     // handle error (optional rollback)
   } finally {
     // remove the swiped user from stack
-    candidates.value = candidates.value.filter((x) => x.userId !== userId)
+    store.remove(userId)
   }
 }
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -34,6 +34,12 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/preferences',
+      name: 'preferences',
+      component: () => import('../views/PreferencesView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/chat/:id',
       name: 'chat',
       component: () => import('../views/ChatView.vue'), // lazy-loaded

--- a/src/stores/candidates.ts
+++ b/src/stores/candidates.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+import axios from 'axios'
+
+const API_BASE = import.meta.env.VITE_API_BASE
+
+export const useCandidates = defineStore('candidates', {
+  state: () => ({
+    list: [] as any[],
+  }),
+  actions: {
+    async fetch() {
+      const { data } = await axios.get(`${API_BASE}/users/candidates`)
+      this.list = data || []
+    },
+    remove(id: string) {
+      this.list = this.list.filter((x: any) => x.userId !== id)
+    },
+  },
+})

--- a/src/views/PreferencesView.vue
+++ b/src/views/PreferencesView.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import Header from '@/components/Header.vue'
+import axios from 'axios'
+import { useCandidates } from '@/stores/candidates'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const candidates = useCandidates()
+
+const gender = ref('any')
+const ageMin = ref(18)
+const ageMax = ref(100)
+const distanceKm = ref(50)
+const error = ref('')
+const success = ref(false)
+const API_BASE = import.meta.env.VITE_API_BASE
+
+onMounted(async () => {
+  try {
+    const { data } = await axios.get(`${API_BASE}/users/me/preferences`)
+    gender.value = data.gender || 'any'
+    ageMin.value = data.ageMin ?? 18
+    ageMax.value = data.ageMax ?? 100
+    distanceKm.value = data.distanceKm ?? 50
+  } catch (e) {
+    // ignore
+  }
+})
+
+async function save() {
+  error.value = ''
+  try {
+    await axios.put(`${API_BASE}/users/me/preferences`, {
+      gender: gender.value,
+      ageMin: ageMin.value,
+      ageMax: ageMax.value,
+      distanceKm: distanceKm.value,
+    })
+    await candidates.fetch()
+    success.value = true
+    setTimeout(() => router.push('/dashboard'), 1000)
+  } catch (e: any) {
+    error.value = e.response?.data?.message || e.message
+  }
+}
+</script>
+
+<template>
+  <main>
+    <Header />
+    <div class="p-4 max-w-md mx-auto text-white">
+      <h1 class="text-xl mb-4">Preferences</h1>
+      <form @submit.prevent="save" class="space-y-4">
+        <div>
+          <label class="block mb-1">Gender</label>
+          <select v-model="gender" class="w-full text-black p-2 rounded">
+            <option value="any">Any</option>
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+          </select>
+        </div>
+        <div>
+          <label class="block mb-1">Age Min</label>
+          <input type="number" v-model.number="ageMin" class="w-full text-black p-2 rounded" />
+        </div>
+        <div>
+          <label class="block mb-1">Age Max</label>
+          <input type="number" v-model.number="ageMax" class="w-full text-black p-2 rounded" />
+        </div>
+        <div>
+          <label class="block mb-1">Distance (km)</label>
+          <input type="number" v-model.number="distanceKm" class="w-full text-black p-2 rounded" />
+        </div>
+        <p v-if="error" class="text-red-400 text-sm">{{ error }}</p>
+        <p v-if="success" class="text-emerald-400 text-sm">Saved!</p>
+        <button type="submit" class="mt-2 px-4 py-2 bg-pink-500 rounded text-white">Save</button>
+      </form>
+    </div>
+  </main>
+</template>


### PR DESCRIPTION
## Summary
- add user preferences page with gender/age/distance filters
- refresh swipe candidates after saving
- link preferences in header and router

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a5957f4b68832292faa5bb57cb2516