### PR TITLE
feat: add preferences page

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- Site-wide navigation bar -->
   <header class="w-full">
     <div class="mx-auto mt-3 px-4">
       <nav
@@ -21,6 +22,7 @@
         </div>
 
         <!-- Center nav (desktop) -->
+        <!-- Desktop navigation links -->
         <ul class="hidden items-center gap-6 md:flex">
           <li>
             <RouterLink
@@ -40,11 +42,20 @@
               Matches
             </RouterLink>
           </li>
+          <li>
+            <RouterLink
+              to="/preferences"
+              class="text-sm text-white/80 hover:text-white transition"
+              :class="isActive('/preferences')"
+            >
+              Preferences
+            </RouterLink>
+          </li>
         </ul>
 
         <!-- Right actions -->
+        <!-- User actions: logout and profile link -->
         <div class="flex items-center gap-2">
-          <!-- Avatar -->
           <button class="text-white" @click="onLogout">Logout</button>
           <RouterLink to="/createprofile" class="flex items-center gap-2" title="Your profile">
             <img
@@ -60,7 +71,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { onMounted, onBeforeUnmount } from 'vue'
 import { useRouter, useRoute, RouterLink } from 'vue-router'
 
 const router = useRouter()
@@ -71,8 +82,6 @@ const route = useRoute()
 const props = defineProps<{ avatarUrl?: string }>()
 const defaultAvatar =
   'https://api.dicebear.com/7.x/initials/svg?seed=T&backgroundType=gradientLinear&backgroundColor=f472b6,8b5cf6'
-const open = ref(false)
-
 function onLogout() {
   localStorage.removeItem('jwt')
   localStorage.removeItem('userId')
@@ -83,9 +92,11 @@ function isActive(path: string) {
   return route.path === path ? 'text-white' : ''
 }
 
-// Close menu on outside click or Escape
+// Close potential menus on Escape keypress (future use)
 function handleKey(e: KeyboardEvent) {
-  if (e.key === 'Escape') open.value = false
+  if (e.key === 'Escape') {
+    // placeholder for menu-close logic
+  }
 }
 onMounted(() => document.addEventListener('keydown', handleKey))
 onBeforeUnmount(() => document.removeEventListener('keydown', handleKey))

--- a/src/components/SwipeCarousel.vue
+++ b/src/components/SwipeCarousel.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="relative flex items-center justify-center h-dvh bg-[#0b0d12]">
     <div v-if="candidates.length" class="relative w-80 h-[460px]">
+      <!-- Render a stack of swipeable cards -->
       <SwipeCarouselCard
         v-for="(u, i) in candidates"
-        :key="u._id || u.id"
+        :key="u.userId"
         :user="u"
         :style="{ zIndex: candidates.length - i }"
         @swipe="onSwipe"
@@ -13,33 +14,38 @@
       v-if="!candidates.length"
       class="relative w-80 h-[460px] flex items-center justify-center text-white/60"
     >
+      <!-- Message shown when there are no candidates to swipe on -->
       No more candidates available.
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onMounted } from 'vue'
 import SwipeCarouselCard from '@/components/SwipeCarouselCard.vue'
-import axios from 'axios'
+import api from '@/lib/api'
+import { useCandidates } from '@/stores/candidates'
 
-const candidates = ref([] as any[])
+// Access the candidate store and expose its list
+const store = useCandidates()
+const candidates = computed(() => store.list)
 
-// Load once or when needed
-async function fetchCandidates() {
-  const { data } = await axios.get('/api/users/candidates')
-  candidates.value = data || []
-}
-fetchCandidates()
+// Load candidates the first time the carousel mounts
+onMounted(() => {
+  if (!store.list.length) {
+    store.fetch()
+  }
+})
 
+// Handle like/dislike swipes and notify the backend
 async function onSwipe({ direction, userId }: { direction: 'left' | 'right'; userId: string }) {
   try {
-    await axios.post('/api/users/swipes', { targetId: userId, direction })
+    await api.post('/users/swipes', { targetId: userId, direction })
   } catch (e) {
-    // handle error (optional rollback)
+    // Optionally handle errors (network issues, etc.)
   } finally {
-    // remove the swiped user from stack
-    candidates.value = candidates.value.filter((x) => x.userId !== userId)
+    // Always remove the swiped user from the stack
+    store.remove(userId)
   }
 }
 </script>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,27 @@
+import axios from 'axios'
+import router from '@/router'
+
+// Axios instance configured with API base URL
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE,
+})
+
+// Attach JWT token to every request if it exists
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('jwt')
+  if (token) config.headers.Authorization = `Bearer ${token}`
+  return config
+})
+
+// Redirect to login on unauthorized responses
+api.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response?.status === 401) {
+      router.push('/')
+    }
+    return Promise.reject(err)
+  },
+)
+
+export default api

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,7 @@ import { useAuth } from '@/stores/auth'
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
+    // Public routes
     {
       path: '/',
       name: 'login',
@@ -15,6 +16,8 @@ const router = createRouter({
       name: 'createaccount',
       component: () => import('../views/CreateAccountView.vue'), // lazy-loaded
     },
+
+    // Authenticated routes
     {
       path: '/createprofile',
       name: 'createprofile',
@@ -34,16 +37,25 @@ const router = createRouter({
       meta: { requiresAuth: true },
     },
     {
+      path: '/preferences',
+      name: 'preferences',
+      component: () => import('../views/PreferencesView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/chat/:id',
       name: 'chat',
       component: () => import('../views/ChatView.vue'), // lazy-loaded
-      props: true, // allows ChatView to accept prop 'id' if desired
+      props: true, // allows ChatView to accept prop 'id'
       meta: { requiresAuth: true },
     },
+
+    // Fallback
     { path: '/:pathMatch(.*)*', redirect: '/' },
   ],
 })
 
+// Basic auth guard: redirect unauthenticated users to login
 router.beforeEach((to, from, next) => {
   const auth = useAuth()
   const requiresAuth = to.matched.some((record) => record.meta.requiresAuth)

--- a/src/stores/candidates.ts
+++ b/src/stores/candidates.ts
@@ -1,0 +1,27 @@
+import { defineStore } from 'pinia'
+import api from '@/lib/api'
+
+// Simple candidate type used by the store
+interface Candidate {
+  userId: string
+  profile: Record<string, unknown>
+}
+
+// Centralized store for swipe candidates
+export const useCandidates = defineStore('candidates', {
+  // Hold the list of candidates returned from the API
+  state: () => ({
+    list: [] as Candidate[],
+  }),
+  actions: {
+    // Load fresh candidates from the backend
+    async fetch() {
+      const { data } = await api.get('/users/candidates')
+      this.list = data || []
+    },
+    // Remove a candidate after swiping
+    remove(id: string) {
+      this.list = this.list.filter((x: Candidate) => x.userId !== id)
+    },
+  },
+})

--- a/src/views/PreferencesView.vue
+++ b/src/views/PreferencesView.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import Header from '@/components/Header.vue'
+import api from '@/lib/api'
+import { useCandidates } from '@/stores/candidates'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const candidates = useCandidates()
+
+// Preference fields bound to the form inputs
+const gender = ref('any')
+const ageMin = ref(18)
+const ageMax = ref(100)
+const distanceKm = ref(50)
+const error = ref('')
+const success = ref(false)
+
+// Load existing preferences when the page mounts
+onMounted(async () => {
+  try {
+    const { data } = await api.get('/users/me/preferences')
+    gender.value = data.gender || 'any'
+    ageMin.value = data.ageMin ?? 18
+    ageMax.value = data.ageMax ?? 100
+    distanceKm.value = data.distanceKm ?? 50
+  } catch (e) {
+    // Ignore failure and let user enter values manually
+  }
+})
+
+// Persist the user's preferences and refresh candidates
+async function save() {
+  error.value = ''
+  try {
+    await api.put('/users/me/preferences', {
+      gender: gender.value,
+      ageMin: ageMin.value,
+      ageMax: ageMax.value,
+      distanceKm: distanceKm.value,
+    })
+    await candidates.fetch()
+    success.value = true
+    setTimeout(() => router.push('/dashboard'), 1000)
+  } catch (e: any) {
+    error.value = e.response?.data?.message || e.message
+  }
+}
+</script>
+
+<template>
+  <main>
+    <Header />
+    <div class="p-4 max-w-md mx-auto text-white">
+      <h1 class="text-xl mb-4">Preferences</h1>
+      <!-- User preference form -->
+      <form @submit.prevent="save" class="space-y-4">
+        <div>
+          <label class="block mb-1">Gender</label>
+          <select v-model="gender" class="w-full text-black p-2 rounded">
+            <option value="any">Any</option>
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+          </select>
+        </div>
+        <div>
+          <label class="block mb-1">Age Min</label>
+          <input type="number" v-model.number="ageMin" class="w-full text-black p-2 rounded" />
+        </div>
+        <div>
+          <label class="block mb-1">Age Max</label>
+          <input type="number" v-model.number="ageMax" class="w-full text-black p-2 rounded" />
+        </div>
+        <div>
+          <label class="block mb-1">Distance (km)</label>
+          <input type="number" v-model.number="distanceKm" class="w-full text-black p-2 rounded" />
+        </div>
+        <!-- Error/success feedback -->
+        <p v-if="error" class="text-red-400 text-sm">{{ error }}</p>
+        <p v-if="success" class="text-emerald-400 text-sm">Saved!</p>
+        <button type="submit" class="mt-2 px-4 py-2 bg-pink-500 rounded text-white">Save</button>
+      </form>
+    </div>
+  </main>
+</template>


### PR DESCRIPTION
## Summary
- add user preferences page with gender/age/distance filters
- refresh swipe candidates after saving
- link preferences in header and router
- centralize API client and document components

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a5957f4b68832292faa5bb57cb2516